### PR TITLE
`untar`: Fix usage of a deprecated environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `sync_resources`: Sync a Viash package's test resources to the local filesystem (PR #7).
 
+## BUG FIXES
+
+* `untar`: Fix usage of a deprecated environment variable (PR #8).
+
 # craftbox 0.1.0
 
 ## NEW FEATURES

--- a/src/untar/script.sh
+++ b/src/untar/script.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 extra_args=()
 
-TMPDIR=$(mktemp -d "$meta_temp_dir/$meta_functionality_name-XXXXXX")
+TMPDIR=$(mktemp -d "$meta_temp_dir/$meta_name-XXXXXX")
 function clean_up {
   [[ -d "$TMPDIR" ]] && rm -r "$TMPDIR"
 }

--- a/src/untar/test.sh
+++ b/src/untar/test.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 # create tempdir
 echo ">>> Creating temporary test directory."
-TMPDIR=$(mktemp -d "$meta_temp_dir/$meta_functionality_name-XXXXXX")
+TMPDIR=$(mktemp -d "$meta_temp_dir/$meta_name-XXXXXX")
 function clean_up {
   [[ -d "$TMPDIR" ]] && rm -r "$TMPDIR"
 }


### PR DESCRIPTION
Fixes #5